### PR TITLE
SetGestureConfig allows more then one config

### DIFF
--- a/WinTouch/NativeMethods.cs
+++ b/WinTouch/NativeMethods.cs
@@ -91,7 +91,7 @@ namespace Alteridem.WinTouch
         /// <returns></returns>
         public static bool SetGestureConfig( IntPtr hwnd, GestureConfig[] configs )
         {
-            return _pSetGestureConfig( hwnd, 0, 1, configs, (uint)Marshal.SizeOf( typeof( GestureConfig ) ) );
+            return _pSetGestureConfig( hwnd, 0, (uint)configs.Length, configs, (uint)Marshal.SizeOf( typeof( GestureConfig ) ) );
         }
 
         /// <summary>


### PR DESCRIPTION
Hello @rprouse  thanks for this nice library.
I had trouble setting up more then one GestureConfig, only the first config would be accepted.

In the documentation I found that the third parameter "cIDs" should be: "A count of the gesture configuration structures that are being passed." In the current version, this parameter is always set to 1. My pull request sets this parameter to the length of the configuration array.

Documentation for reference:
https://docs.microsoft.com/sv-se/windows/win32/api/winuser/nf-winuser-setgestureconfig