### PR TITLE
Set m_configs before using it.

### DIFF
--- a/WinTouch/GestureListener.cs
+++ b/WinTouch/GestureListener.cs
@@ -74,6 +74,8 @@ namespace Alteridem.WinTouch
         /// <param name="configs">The gesture configurations.</param>
         public GestureListener( Control parent, GestureConfig[] configs )
         {
+            m_configs = configs;
+
             if ( parent.IsHandleCreated )
             {
                 Initialize( parent );
@@ -83,8 +85,6 @@ namespace Alteridem.WinTouch
                 parent.HandleCreated += OnHandleCreated;
             }
             parent.HandleDestroyed += OnHandleDestroyed;
-
-            m_configs = configs;
         }
 
         #endregion


### PR DESCRIPTION
Currently when initializing GestureListener - it tries internally use m_configs before set it to argument and without null check. 